### PR TITLE
feat: ignore helm templates by directory

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,4 +5,4 @@ rules:
   line-length: disable
 
 ignore:
-  - ./chart/templates/*
+  - 'chart/templates/*'

--- a/.yamllint
+++ b/.yamllint
@@ -3,3 +3,6 @@ extends: default
 
 rules:
   line-length: disable
+
+ignore: |
+  ./chart/templates/*

--- a/.yamllint
+++ b/.yamllint
@@ -4,5 +4,5 @@ extends: default
 rules:
   line-length: disable
 
-ignore: |
-  ./chart/templates/*
+ignore:
+  - ./chart/templates/*

--- a/chart/templates/cluster-applications.yaml
+++ b/chart/templates/cluster-applications.yaml
@@ -1,5 +1,3 @@
-# yamllint disable-file
-# This file is not valid YAML because it is a template
 {{- range .Values.projects }}
   {{- $project := . }}
   {{- range .clusters }}


### PR DESCRIPTION
I noticed the yamllint directive making it into the rendered manifests: https://github.com/DaneWeber/argo-cd-app-of-apps-of-apps/pull/6/files

Let's not do that.